### PR TITLE
add seq_db to enable phmmer searches

### DIFF
--- a/hmmer/__init__.py
+++ b/hmmer/__init__.py
@@ -4,7 +4,7 @@ from . import typing
 from ._example import example_filepath
 from ._testit import test
 from .domtbl import read_domtbl
-from .hmmer import HMMER
+from .hmmer import HMMER, seq_db
 from .tbl import read_tbl
 
 try:
@@ -14,6 +14,7 @@ except ModuleNotFoundError:
 
 __all__ = [
     "HMMER",
+    "seq_db",
     "__version__",
     "example_filepath",
     "read_domtbl",

--- a/hmmer/__init__.py
+++ b/hmmer/__init__.py
@@ -4,7 +4,7 @@ from . import typing
 from ._example import example_filepath
 from ._testit import test
 from .domtbl import read_domtbl
-from .hmmer import HMMER, seq_db
+from .hmmer import HMMER, SeqDB
 from .tbl import read_tbl
 
 try:
@@ -14,7 +14,7 @@ except ModuleNotFoundError:
 
 __all__ = [
     "HMMER",
-    "seq_db",
+    "SeqDB",
     "__version__",
     "example_filepath",
     "read_domtbl",

--- a/hmmer/_example.py
+++ b/hmmer/_example.py
@@ -11,7 +11,7 @@ goodboy = pooch.create(
     path=pooch.os_cache("hmmer"),
     base_url="https://hmmer-py.s3.eu-west-2.amazonaws.com/",
     registry={
-        "Pfam-A_24.hmm.gz": "32791a1b50837cbe1fca1376a3e1c45bc84b32dd4fe28c92fd276f3f2c3a15e3",
+        "Pfam-A_24.hmm.gz": "32791a1b50837cbe1fca1376a3e1c45bc84b32dd4fe28c92fd276f3f2c3a15e3"
     },
 )
 

--- a/hmmer/bin/__init__.py
+++ b/hmmer/bin/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path as _Path
 from sys import platform as _platform
 
-__all__ = ["hmmfetch", "hmmpress", "hmmscan", "hmmsearch", "hmmemit"]
+__all__ = ["hmmfetch", "hmmpress", "hmmscan", "hmmsearch", "hmmemit", "phmmer"]
 
 if _platform not in ["linux", "darwin"]:
     raise RuntimeError(f"Unsupported platform: {_platform}.")
@@ -18,3 +18,4 @@ hmmfetch = _bin / f"hmmfetch_{_suffix}"
 hmmpress = _bin / f"hmmpress_{_suffix}"
 hmmscan = _bin / f"hmmscan_{_suffix}"
 hmmsearch = _bin / f"hmmsearch_{_suffix}"
+phmmer = _bin / f"phmmer_{_suffix}"

--- a/hmmer/hmmer.py
+++ b/hmmer/hmmer.py
@@ -12,7 +12,7 @@ from .bin import hmmemit, hmmfetch, hmmpress, hmmscan, hmmsearch, phmmer
 from .domtbl import DomTBLRow, read_domtbl
 from .tbl import TBLRow, read_tbl
 
-__all__ = ["HMMER", "Result", "seq_db"]
+__all__ = ["HMMER", "Result", "SeqDB"]
 
 
 class State(Enum):
@@ -269,7 +269,7 @@ class HMMER:
         return Result(options.tblout, options.domtblout)
 
 
-class seq_db:
+class SeqDB:
     def __init__(self, db: Union[Path, str]):
         self.sequences = make_path(db).absolute()
         self._timeout = 15

--- a/hmmer/hmmer.py
+++ b/hmmer/hmmer.py
@@ -53,7 +53,7 @@ class Result:
 
 
 def _optional_filepath(
-        filepath_or_bool: Union[Path, str, bool], tmp_filepath: Path
+    filepath_or_bool: Union[Path, str, bool], tmp_filepath: Path
 ) -> Optional[Path]:
     if isinstance(filepath_or_bool, str):
         filepath_or_bool = Path(filepath_or_bool)
@@ -291,15 +291,15 @@ class seq_db:
         return Result(options.tblout, options.domtblout)
 
     def phmmer(
-            self,
-            target: Union[Path, str, TextIO],
-            output: Optional[Union[Path, str]] = None,
-            tblout: Union[Path, str, bool] = True,
-            domtblout: Union[Path, str, bool] = True,
-            heuristic=True,
-            cut_ga=False,
-            hmmkey: Optional[str] = None,
-            Z: Optional[int] = None,
+        self,
+        target: Union[Path, str, TextIO],
+        output: Optional[Union[Path, str]] = None,
+        tblout: Union[Path, str, bool] = True,
+        domtblout: Union[Path, str, bool] = True,
+        heuristic=True,
+        cut_ga=False,
+        hmmkey: Optional[str] = None,
+        Z: Optional[int] = None,
     ) -> Result:
 
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/hmmer/hmmer.py
+++ b/hmmer/hmmer.py
@@ -8,11 +8,11 @@ from typing import List, Optional, TextIO, Union
 from fasta_reader import FASTAItem, read_fasta
 
 from ._misc import make_path
-from .bin import hmmemit, hmmfetch, hmmpress, hmmscan, hmmsearch
+from .bin import hmmemit, hmmfetch, hmmpress, hmmscan, hmmsearch, phmmer
 from .domtbl import DomTBLRow, read_domtbl
 from .tbl import TBLRow, read_tbl
 
-__all__ = ["HMMER", "Result"]
+__all__ = ["HMMER", "Result", "seq_db"]
 
 
 class State(Enum):
@@ -53,9 +53,8 @@ class Result:
 
 
 def _optional_filepath(
-    filepath_or_bool: Union[Path, str, bool], tmp_filepath: Path
+        filepath_or_bool: Union[Path, str, bool], tmp_filepath: Path
 ) -> Optional[Path]:
-
     if isinstance(filepath_or_bool, str):
         filepath_or_bool = Path(filepath_or_bool)
 
@@ -268,3 +267,45 @@ class HMMER:
             check_call(cmd_match)
 
         return Result(options.tblout, options.domtblout)
+
+
+class seq_db:
+    def __init__(self, db: Union[Path, str]):
+        self.sequences = make_path(db).absolute()
+        self._timeout = 15
+
+    @property
+    def timeout(self) -> int:
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, timeout: int):
+        self._timeout = timeout
+
+    def _match(self, bin: Path, target: Path, options: Options) -> Result:
+        target = target.absolute()
+        sequence_db = self.sequences
+        cmd_match = [str(bin)] + options.aslist() + [str(target), str(sequence_db)]
+        check_call(cmd_match)
+
+        return Result(options.tblout, options.domtblout)
+
+    def phmmer(
+            self,
+            target: Union[Path, str, TextIO],
+            output: Optional[Union[Path, str]] = None,
+            tblout: Union[Path, str, bool] = True,
+            domtblout: Union[Path, str, bool] = True,
+            heuristic=True,
+            cut_ga=False,
+            hmmkey: Optional[str] = None,
+            Z: Optional[int] = None,
+    ) -> Result:
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tbl_file = _optional_filepath(tblout, Path(tmpdir) / "tbl.txt")
+            domtbl_file = _optional_filepath(domtblout, Path(tmpdir) / "domtbl.txt")
+
+            opts = Options(output, tbl_file, domtbl_file, heuristic, cut_ga, hmmkey, Z)
+            target = make_target(target, Path(tmpdir))
+            return self._match(phmmer, target, opts)


### PR DESCRIPTION
I added I sequence_database class with a phmmer method to allow a phmmer search against that database.
The binaries for phmmer still need to be added and should probably all be updated to the new hmmer version 3.3.2